### PR TITLE
Add java toolchain

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,12 +2,10 @@ plugins {
     java
 }
 
-repositories {
-
-}
-
-dependencies {
-
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(19))
+    }
 }
 
 tasks {


### PR DESCRIPTION
This pr adds the java toolchain configuration to the gradle build script. Java 19 is used.