### PR TITLE
Run gradle `validateCommits` task with info logging

### DIFF
--- a/.github/workflows/conventional_commits.yml
+++ b/.github/workflows/conventional_commits.yml
@@ -15,4 +15,4 @@ jobs:
           distribution: temurin
           java-version: 18
       - uses: gradle/gradle-build-action@v2
-      - run: gradle validateCommits
+      - run: gradle validateCommits -i


### PR DESCRIPTION
This pr adds the `-i` argument to `gradle validateCommits` to enable logging of all "info" level logs.
