### PR TITLE
Fix wrongly formatted error msg

### DIFF
--- a/buildSrc/src/main/java/tequila/ValidateCommitMessageGitTask.java
+++ b/buildSrc/src/main/java/tequila/ValidateCommitMessageGitTask.java
@@ -68,7 +68,7 @@ public class ValidateCommitMessageGitTask extends DefaultTask {
             var type = matcher.group("type");
             var scope = matcher.group("scope");
             if (!types.contains(type)) {
-                errors.add("-> Unkown type '%header'".formatted());
+                errors.add("-> Unkown type '%s'".formatted(type));
             }
             if (scope != null && !scopes.contains(scope)) {
                 errors.add("-> Unkown scope '%s'".formatted(scope));


### PR DESCRIPTION
Fixes an wrong format string, causing a wrong conventional commit type to be not handled by the git hook.